### PR TITLE
define (and declare) FileDescriptor::BUFFER_SIZE

### DIFF
--- a/src/file_descriptor.cc
+++ b/src/file_descriptor.cc
@@ -59,6 +59,7 @@ string::const_iterator FileDescriptor::write( const string::const_iterator & beg
 /* read method */
 string FileDescriptor::read( const size_t limit )
 {
+  constexpr size_t BUFFER_SIZE = 1024 * 1024;   /* maximum size of a read */
   char buffer[ BUFFER_SIZE ];
 
   ssize_t bytes_read = SystemCall( "read", ::read( fd_, buffer, min( BUFFER_SIZE, limit ) ) );

--- a/src/file_descriptor.hh
+++ b/src/file_descriptor.hh
@@ -1,6 +1,7 @@
 #ifndef FILE_DESCRIPTOR_HH
 #define FILE_DESCRIPTOR_HH
 
+#include <limits>
 #include <string>
 
 /* Unix file descriptors (sockets, files, etc.) */
@@ -15,9 +16,6 @@ private:
   /* attempt to write a portion of a string */
   std::string::const_iterator write( const std::string::const_iterator & begin,
 				     const std::string::const_iterator & end );
-
-  /* maximum size of a read */
-  const static size_t BUFFER_SIZE = 1024 * 1024;
 
 protected:
   void register_read() { read_count_++; }
@@ -41,7 +39,7 @@ public:
   unsigned int write_count() const { return write_count_; }
 
   /* read and write methods */
-  std::string read( const size_t limit = BUFFER_SIZE );
+  std::string read( const size_t limit = std::numeric_limits<size_t>::max() );
   std::string::const_iterator write( const std::string & buffer, const bool write_all = true );
 
   /* forbid copying FileDescriptor objects or assigning them */


### PR DESCRIPTION
FileDescriptor::BUFFER_SIZE is declared in file_descriptor.hh but not
defined in file_descriptor.cc. This (sometimes) causes an error when
linking the example programs against libsourdough.a.

This error is masked when libsourdough is built with -O2, because
FileDescriptor::BUFFER_SIZE gets const-folded away. But you can reveal
this error by building the prior version of the code without
optimizations:

    ./autogen.sh
    CXXFLAGS="-Og -ggdb3" ./configure
    make
    .
    .
    .
    /sbin/ld: libsourdough.a(file_descriptor.cc.o): in function `FileDescriptor::read[abi:cxx11](unsigned long)':
    /usr/include/c++/8.2.1/bits/stl_algobase.h:202: undefined reference to `FileDescriptor::BUFFER_SIZE'
    collect2: error: ld returned 1 exit status

This commit fixes the above issue.

Tested with g++ 8.2.1 and clang++ 7.0.0.